### PR TITLE
feat: implement a cached version of bounds computation

### DIFF
--- a/incomplete_cooperative/bounds.py
+++ b/incomplete_cooperative/bounds.py
@@ -1,7 +1,15 @@
 """Compute bounds for an incomplete game."""
+from functools import cache
+from typing import Any
+
 import numpy as np
 
-from .coalitions import (all_coalitions, get_sub_coalitions,
+from .coalition_ids import CoalitionId
+from .coalition_ids import all_coalitions as all_coalitions_id
+from .coalition_ids import size
+from .coalition_ids import sub_coalitions as get_sub_coalitions_id
+from .coalition_ids import super_coalitions as get_super_coalitions_id
+from .coalitions import (Coalition, all_coalitions, get_sub_coalitions,
                          get_super_coalitions)
 from .protocols import BoundableIncompleteGame
 
@@ -22,6 +30,48 @@ def compute_bounds_superadditive(game: BoundableIncompleteGame) -> None:
         game.set_upper_bound(upper_bound, coalition)
 
 
+@cache
+def _get_sub_super_coalition_structure(number_of_players: int) -> tuple[
+    np.ndarray[Any, np.dtype[CoalitionId]],
+    np.ndarray[Any, np.dtype[CoalitionId]],
+    np.ndarray[Any, np.dtype[CoalitionId]]
+]:
+    """Get the system of subcoalitions and supercoalitions of a given coalition."""
+    r = []
+    for coalition in all_coalitions_id(number_of_players):
+        all_coals = np.zeros(2**number_of_players)
+        sub_coals = get_sub_coalitions_id(coalition, number_of_players)
+        all_coals[sub_coals] = 1
+        super_coals = get_super_coalitions_id(coalition, number_of_players)
+        all_coals[super_coals] = 2
+        all_coals[coalition] = 0
+        r.append(all_coals)
+    sizes = np.array([size(coal, number_of_players) for coal in all_coalitions_id(number_of_players)])
+    all_sorted = all_coalitions_id(number_of_players)[np.argsort(sizes)]
+    return all_coalitions_id(number_of_players), all_sorted, np.array(r)
+
+
+def compute_bounds_superadditive_cached(game: BoundableIncompleteGame) -> None:
+    """Compute the bounds given a superadditive incomplete game."""
+    assert game.is_value_known(Coalition(0))
+    assert game.is_value_known(Coalition(2**game.number_of_players - 1))
+    all_coalitions, all_sorted, coal_structure = _get_sub_super_coalition_structure(game.number_of_players)
+    unknown_sorted = all_sorted[np.logical_not(game.are_values_known()[all_sorted])]
+    for coalition in unknown_sorted:
+        sub_coalitions = all_coalitions[coal_structure[coalition] == 1]
+        complementary_coalitions = coalition ^ sub_coalitions
+        lower_bound = np.max(game.get_lower_bounds()[sub_coalitions] + game.get_lower_bounds()[complementary_coalitions])
+        game.set_lower_bound(lower_bound, Coalition(coalition))
+
+    for coalition in unknown_sorted:
+        super_coalitions = all_coalitions[coal_structure[coalition] == 2]
+        known_super_coalitions = super_coalitions[game.are_values_known()[super_coalitions]]
+        complementary_coalitions = coalition ^ known_super_coalitions
+        upper_bound = np.min(game.get_lower_bounds()[known_super_coalitions] - game.get_lower_bounds()[complementary_coalitions])
+        game.set_upper_bound(upper_bound, Coalition(coalition))
+
+
 BOUNDS = {
     "superadditive": compute_bounds_superadditive,
+    "superadditive_cached": compute_bounds_superadditive_cached,
 }

--- a/incomplete_cooperative/coalition_ids.py
+++ b/incomplete_cooperative/coalition_ids.py
@@ -1,0 +1,45 @@
+"""In this module, Coalition computations are performed in numpy using coalition ids."""
+from typing import Any
+
+import numpy as np
+
+CoalitionId = np.int32
+
+
+def all_coalitions(number_of_players: int | np.integer) -> np.ndarray[Any, np.dtype[CoalitionId]]:
+    """Get the set of all coalitions for a game."""
+    return np.arange(2**number_of_players, dtype=CoalitionId)
+
+
+def players(coalition: CoalitionId, number_of_players: int) -> np.ndarray[Any, np.dtype[np.int32]]:
+    """Get players in a coalition.
+
+    number_of_players is the total number of players in the game.
+    """
+    assert 2**number_of_players > coalition, "Coalition has more players than number_of_players allows."
+    return np.arange(number_of_players)[2**np.arange(number_of_players) & coalition != 0]
+
+
+def size(coalition: CoalitionId, number_of_players: int) -> np.ndarray[Any, np.dtype[np.int32]]:
+    """Get players in a coalition.
+
+    number_of_players is the total number of players in the game.
+    """
+    assert 2**number_of_players > coalition, f"Coalition {coalition} has more players than number_of_players allows - {number_of_players}."
+    return (2**np.arange(number_of_players) & coalition != 0).sum()
+
+
+def sub_coalitions(coalition: CoalitionId, number_of_players: int) -> np.ndarray[Any, np.dtype[CoalitionId]]:
+    """Get subcoalitions of a coalition."""
+    assert 2**number_of_players > coalition, f"Coalition {coalition} has more players than number_of_players allows - {number_of_players}."
+    max_num_players = np.max(players(coalition, number_of_players), initial=0) + 1
+    return all_coalitions(max_num_players)[all_coalitions(max_num_players) | coalition == coalition]
+
+
+def super_coalitions(coalition: CoalitionId, number_of_players: int) -> np.ndarray[Any, np.dtype[CoalitionId]]:
+    """Get subcoalitions of a coalition."""
+    assert 2**number_of_players > coalition, f"Coalition {coalition} has more players than number_of_players allows - {number_of_players}."
+
+    opposite_coalition = (2**number_of_players - 1) ^ coalition
+    opposite_sub = sub_coalitions(opposite_coalition, number_of_players)
+    return opposite_sub | coalition

--- a/incomplete_cooperative/evaluation.py
+++ b/incomplete_cooperative/evaluation.py
@@ -23,7 +23,7 @@ def evaluate(get_next_step: Callable, env: Gym,
         for episode in range(run_steps_limit):
             action = get_next_step(env)
             _, _, done, _, info = env.step(action)
-            known_coalitions.append(env.explorable_coalitions[action])
+            known_coalitions.append(env.get_wrapper_attr("explorable_coalitions")[action])
 
             # reveal the same coalitions on the non-normalized game, compute its exploitability
             incomplete_game.set_known_values(game.get_values(known_coalitions), known_coalitions)

--- a/incomplete_cooperative/evaluation.py
+++ b/incomplete_cooperative/evaluation.py
@@ -14,8 +14,8 @@ def evaluate(get_next_step: Callable, env: Gym,
     for repetition in range(repetitions):
         _, base_info = env.reset()
         game = base_info["game"]
-        incomplete_game = env.incomplete_game.copy()
-        known_coalitions = env.initially_known_coalitions.copy()
+        incomplete_game = env.get_wrapper_attr("incomplete_game").copy()
+        known_coalitions = env.get_wrapper_attr("initially_known_coalitions").copy()
 
         incomplete_game.set_known_values(game.get_values(known_coalitions), known_coalitions)
         incomplete_game.compute_bounds()

--- a/incomplete_cooperative/protocols.py
+++ b/incomplete_cooperative/protocols.py
@@ -176,6 +176,9 @@ class Gym(Protocol):
     def explorable_coalitions(self) -> list[Coalition]:
         """A list of coalitions that aren't initially known."""
 
+    def get_wrapper_attr(self, _: str) -> Any:
+        """Replace the __attr__ old approach."""
+
 
 class Solver(Protocol):
     """A solver of incomplete games.

--- a/incomplete_cooperative/run/eval.py
+++ b/incomplete_cooperative/run/eval.py
@@ -16,7 +16,7 @@ def eval_func(instance: ModelInstance, parsed_args) -> None:
 
     def eval_next_step(env):
         action_masks = get_action_masks(env)
-        obs = env.state
+        obs = env.get_wrapper_attr("state")
         action, _ = model.predict(
             obs, action_masks=action_masks, deterministic=parsed_args.eval_deterministic)
         return action

--- a/incomplete_cooperative/run/greedy.py
+++ b/incomplete_cooperative/run/greedy.py
@@ -45,7 +45,7 @@ def get_greedy_rewards(env: ICG_Gym, max_steps: int, repetitions: int, gap_func:
     incomplete_game = env.incomplete_game
     generated_games = [env.generator() for _ in range(repetitions)]
 
-    possible_actions = set(env.explorable_coalitions)
+    possible_actions = set(env.get_wrapper_attr("explorable_coalitions"))
     action_sequence: list[Coalition] = []
     possible_next_action_sequences: list[list[Coalition]] = [[]]
     while len(action_sequence) < max_steps:

--- a/incomplete_cooperative/tests/test_bounds.py
+++ b/incomplete_cooperative/tests/test_bounds.py
@@ -1,9 +1,13 @@
-from unittest import TestCase
+import numpy as np
+import pytest
 
-from incomplete_cooperative.bounds import compute_bounds_superadditive
+from incomplete_cooperative.bounds import (compute_bounds_superadditive,
+                                           compute_bounds_superadditive_cached)
 from incomplete_cooperative.coalitions import (Coalition, all_coalitions,
-                                               grand_coalition)
+                                               grand_coalition,
+                                               minimal_game_coalitions)
 from incomplete_cooperative.game import IncompleteCooperativeGame
+from incomplete_cooperative.generators import convex_generator
 
 
 def dummy_fill(game: IncompleteCooperativeGame) -> None:
@@ -12,31 +16,55 @@ def dummy_fill(game: IncompleteCooperativeGame) -> None:
         game.set_value(len(coalition), coalition)
 
 
-class TestSuperAdditiveBounds(TestCase):
+NUMBER_OF_PLAYERS = 6
 
-    def setUp(self) -> None:
-        self.game = IncompleteCooperativeGame(6, compute_bounds_superadditive)
 
-    def test_full_game(self):
-        dummy_fill(self.game)
-        self.game.compute_bounds()
-        for coalition in all_coalitions(self.game):
-            self.assertEqual(self.game.get_value(coalition), self.game.get_upper_bound(coalition))
-            self.assertEqual(self.game.get_value(coalition), self.game.get_lower_bound(coalition))
+@pytest.fixture
+def game():
+    return IncompleteCooperativeGame(6, compute_bounds_superadditive)
 
-    def test_minimal_game(self):
-        self.game.set_value(2 * self.game.number_of_players, grand_coalition(self.game))
-        for player in range(self.game.number_of_players):
-            self.game.set_value(1, Coalition.from_players([player]))
-        self.game.compute_bounds()
 
-        for coalition in filter(self.game.is_value_known, all_coalitions(self.game)):
-            self.assertEqual(self.game.get_upper_bound(coalition), self.game.get_value(coalition))
-            self.assertEqual(self.game.get_lower_bound(coalition), self.game.get_value(coalition))
+def test_full_game(game):
+    dummy_fill(game)
+    game.compute_bounds()
+    for coalition in all_coalitions(game):
+        assert game.get_value(coalition) == game.get_upper_bound(coalition)
+        assert game.get_value(coalition) == game.get_lower_bound(coalition)
 
-        for coalition in filter(lambda x: not self.game.is_value_known(x), all_coalitions(self.game)):
-            with self.subTest(coalition=coalition):
-                self.assertEqual(self.game.get_upper_bound(coalition), self.game.number_of_players + len(coalition),
-                                 self.game.get_upper_bounds())
-                self.assertEqual(self.game.get_lower_bound(coalition), len(coalition),
-                                 self.game.get_lower_bounds())
+
+def test_minimal_game(game):
+    game.set_value(2 * game.number_of_players, grand_coalition(game))
+    for player in range(game.number_of_players):
+        game.set_value(1, Coalition.from_players([player]))
+    game.compute_bounds()
+
+    for coalition in filter(game.is_value_known, all_coalitions(game)):
+        assert game.get_upper_bound(coalition) == game.get_value(coalition)
+        assert game.get_lower_bound(coalition) == game.get_value(coalition)
+
+    for coalition in filter(lambda x: not game.is_value_known(x), all_coalitions(game)):
+        assert game.get_upper_bound(coalition) == game.number_of_players + len(coalition)
+        assert game.get_lower_bound(coalition) == len(coalition)
+
+
+@pytest.mark.parametrize("rep", range(10))
+def test_cached_nocached_same(rep):
+    min_game = list(minimal_game_coalitions(NUMBER_OF_PLAYERS))
+    incomplete_game = IncompleteCooperativeGame(NUMBER_OF_PLAYERS, compute_bounds_superadditive)
+    incomplete_game_cached = IncompleteCooperativeGame(NUMBER_OF_PLAYERS, compute_bounds_superadditive_cached)
+    game = convex_generator(NUMBER_OF_PLAYERS)
+    incomplete_game.set_known_values(game.get_values(min_game), min_game)
+    incomplete_game_cached.set_known_values(game.get_values(min_game), min_game)
+    incomplete_game.compute_bounds()
+    incomplete_game_cached.compute_bounds()
+    assert np.allclose(incomplete_game_cached.get_upper_bounds(), incomplete_game.get_upper_bounds())
+    assert np.allclose(incomplete_game_cached.get_lower_bounds(), incomplete_game.get_lower_bounds())
+    for step in range(2**game.number_of_players - len(min_game)):
+        unknown = np.arange(2**NUMBER_OF_PLAYERS)[np.logical_not(incomplete_game.are_values_known())]
+        random = np.random.choice(unknown)
+        incomplete_game.reveal_value(game.get_value(Coalition(random)), Coalition(random))
+        incomplete_game.compute_bounds()
+        incomplete_game_cached.reveal_value(game.get_value(Coalition(random)), Coalition(random))
+        incomplete_game_cached.compute_bounds()
+        assert np.allclose(incomplete_game_cached.get_upper_bounds(), incomplete_game.get_upper_bounds())
+        assert np.allclose(incomplete_game_cached.get_lower_bounds(), incomplete_game.get_lower_bounds())

--- a/incomplete_cooperative/tests/test_coalition_ids.py
+++ b/incomplete_cooperative/tests/test_coalition_ids.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from incomplete_cooperative.coalition_ids import players, sub_coalitions
+
+
+def test_players():
+    assert list(players(2, 5)) == [1]
+    assert list(players(3, 5)) == [0, 1]
+    assert list(players(5, 5)) == [0, 2]
+    assert list(players(0, 5)) == []
+
+
+def test_sub_coalition():
+    assert list(sub_coalitions(2, 5)) == [0, 2]
+    assert list(sub_coalitions(3, 5)) == [0, 1, 2, 3]
+    assert list(sub_coalitions(5, 5)) == [0, 1, 4, 5]

--- a/incomplete_cooperative/tests/test_run_save.py
+++ b/incomplete_cooperative/tests/test_run_save.py
@@ -36,7 +36,7 @@ class TestJsonSerializer(TestCase):
                                  {"data": expected})
 
 
-class TestSaverMixin:
+class SaverMixin:
 
     func: str
 
@@ -57,7 +57,7 @@ class TestSaverMixin:
         self.assertEqual(list(x.name for x in self.path.iterdir()), [self.func])
 
 
-class TestJsonSaver(TestSaverMixin, TestCase):
+class TestJsonSaver(SaverMixin, TestCase):
 
     func = "data.json"
 
@@ -107,7 +107,7 @@ class TestJsonSaver(TestSaverMixin, TestCase):
         self.assertTrue(np.isnan(new_output.actions[0, 0]))
 
 
-class TestExplPlotSave(TestSaverMixin, TestCase):
+class TestExplPlotSave(SaverMixin, TestCase):
 
     func = "data_plots"
 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,6 @@ PYTHON=$(VENV)/bin/python
 PIP=$(VENV)/bin/pip
 
 FAIL_UNDER=100
-UNITTEST_MODULE=incomplete_cooperative.tests
 PYTEST_FILE=incomplete_cooperative/tests
 
 test: test_unittest test_types test_docs test_security

--- a/makefile
+++ b/makefile
@@ -4,6 +4,7 @@ PIP=$(VENV)/bin/pip
 
 FAIL_UNDER=100
 UNITTEST_MODULE=incomplete_cooperative.tests
+PYTEST_FILE=incomplete_cooperative/tests
 
 test: test_unittest test_types test_docs test_security
 
@@ -13,7 +14,7 @@ $(VENV)/bin/activate: setup.cfg
 
 test_unittest: $(VENV)/bin/activate
 	$(PYTHON) -m coverage erase
-	$(PYTHON) -m coverage run -m unittest --locals --failfast -k $(UNITTEST_MODULE)
+	$(PYTHON) -m coverage run -m pytest $(PYTEST_FILE)
 	$(PYTHON) -m coverage report -i --show-missing --fail-under=$(FAIL_UNDER)
 	
 test_types: $(VENV)/bin/activate

--- a/performance/bounds_cache_nocache.py
+++ b/performance/bounds_cache_nocache.py
@@ -1,0 +1,33 @@
+"""Compare the time of cached vs non-cached bounds compuing."""
+import timeit
+
+import numpy as np
+
+from incomplete_cooperative.bounds import (compute_bounds_superadditive,
+                                           compute_bounds_superadditive_cached)
+from incomplete_cooperative.coalitions import (Coalition,
+                                               minimal_game_coalitions)
+from incomplete_cooperative.generators import factory_generator
+
+NUM_PL = 6
+NUM = 1000
+
+
+def try_computing_bounds(number_of_players, bounds_computer):
+    """Run a random game, revealing values and computing the bounds."""
+    min_game = list(minimal_game_coalitions(number_of_players))
+    incomplete_game = factory_generator(number_of_players, bounds_computer=bounds_computer)
+    game = factory_generator(number_of_players, bounds_computer=bounds_computer)
+    incomplete_game.set_known_values(game.get_values(min_game), min_game)
+    incomplete_game.compute_bounds()
+
+    for step in range(2**number_of_players - len(min_game)):
+        unknown = np.arange(2**number_of_players)[np.logical_not(incomplete_game.are_values_known())]
+        random = np.random.choice(unknown)
+        incomplete_game.reveal_value(game.get_value(Coalition(random)), Coalition(random))
+        incomplete_game.compute_bounds()
+
+
+print(timeit.timeit(lambda: try_computing_bounds(NUM_PL, compute_bounds_superadditive), number=NUM))
+print(timeit.timeit(lambda: try_computing_bounds(NUM_PL, compute_bounds_superadditive_cached), number=NUM))
+print(timeit.timeit(lambda: try_computing_bounds(NUM_PL, compute_bounds_superadditive), number=NUM))


### PR DESCRIPTION
This new version caches some of the computation ahead of time, and it
uses np more, achieving an approx. 2-3 times speedup for 6 players.
